### PR TITLE
Fix mobile menu closing

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -6,7 +6,7 @@ function Button({ children, variant = 'fill', color = 'accent', href, onClick })
 
   if (href) {
     return (
-      <a className={className} href={href}>
+      <a className={className} href={href} onClick={onClick}>
         {children}
       </a>
     );

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -10,22 +10,42 @@ function Header() {
     setIsMobileMenuOpen(!isMobileMenuOpen);
   };
 
+  const handleNavLinkClick = () => {
+    setIsMobileMenuOpen(false);
+  };
+
   return (
     <header className={styles.header}>
       <div className={styles.container}>
         <div className={styles.logo}>
           {/* Replace with your actual logo image or SVG */}
-          <a href="/">{content.header.logoText}</a>
+          <a href="/" onClick={handleNavLinkClick}>{content.header.logoText}</a>
         </div>
         <nav className={`${styles.nav} ${isMobileMenuOpen ? styles.mobileNavOpen : ''}`}>
           <ul>
             {content.header.navLinks.map((link, index) => (
-              <li key={index}><a href={link.href}>{link.text}</a></li>
+              <li key={index}>
+                <a href={link.href} onClick={handleNavLinkClick}>{link.text}</a>
+              </li>
             ))}
           </ul>
           <div className={styles.authButtons}>
-            <Button variant="outline" color="accent" href={content.header.signInButtonHref}>{content.header.signInButtonText}</Button>
-            <Button variant="fill" color="accent" href={content.header.signUpButtonHref}>{content.header.signUpButtonText}</Button>
+            <Button
+              variant="outline"
+              color="accent"
+              href={content.header.signInButtonHref}
+              onClick={handleNavLinkClick}
+            >
+              {content.header.signInButtonText}
+            </Button>
+            <Button
+              variant="fill"
+              color="accent"
+              href={content.header.signUpButtonHref}
+              onClick={handleNavLinkClick}
+            >
+              {content.header.signUpButtonText}
+            </Button>
           </div>
         </nav>
         <button className={styles.burgerMenu} onClick={toggleMobileMenu} aria-label="Toggle navigation menu">


### PR DESCRIPTION
## Summary
- allow Button links to register clicks
- close mobile menu when navigation links are clicked
- close menu when logo link is clicked

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6848c0faca108328810d32eed10000c4