### PR TITLE
Add tests for Button component

### DIFF
--- a/src/components/Button.test.js
+++ b/src/components/Button.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Button from './Button';
+import styles from '../styles/Button.module.css';
+
+describe('Button component', () => {
+  test('renders as an anchor when href is provided', () => {
+    render(<Button href="/test">Link</Button>);
+    const link = screen.getByRole('link', { name: 'Link' });
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveClass(styles.button, styles.fill, styles.accent);
+  });
+
+  test('renders as a button when onClick is provided', () => {
+    const handleClick = jest.fn();
+    render(<Button onClick={handleClick}>Click</Button>);
+    const button = screen.getByRole('button', { name: 'Click' });
+    expect(button.tagName).toBe('BUTTON');
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalled();
+    expect(button).toHaveClass(styles.button, styles.fill, styles.accent);
+  });
+
+  test('applies variant and color classes', () => {
+    render(
+      <Button variant="outline" color="accent" href="#">
+        Test
+      </Button>
+    );
+    const link = screen.getByRole('link', { name: 'Test' });
+    expect(link).toHaveClass(styles.button, styles.outline, styles.accent);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for Button component verifying anchor/button rendering and CSS classes

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6848d37a312083289cbabfe514a83483