### PR TITLE
Add Artist Dashboard backend plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,5 @@ opened in a browser.
 *   Develop the `/catalog`, `/artist/signup`, and other linked pages.
 *   Replace placeholder content with dynamic data fetched from the backend.
 *   Add actual icons and refine styling based on detailed design assets.
+*   See [docs/artist-dashboard-plan.md](docs/artist-dashboard-plan.md) for a
+    proposed Artist Dashboard backend and adoption strategy.

--- a/docs/artist-dashboard-plan.md
+++ b/docs/artist-dashboard-plan.md
@@ -1,0 +1,67 @@
+# Artist Dashboard Backend Plan
+
+This document outlines a proposed backend structure for the Artist Dashboard and the marketing strategies to promote it.
+
+## 1. Essential Features
+
+### Overview & KPIs
+- Daily, weekly and monthly earnings summaries
+- Upcoming payout schedule
+- Streaming and sales metrics (plays, downloads, territories and top platforms)
+- Growth trends and basic revenue forecasts
+
+### Catalog Management
+- Batch editing of metadata (ISRC, UPC and credits)
+- Release calendar for scheduling drops and embargo dates
+- Version tracking for drafts versus released assets
+
+### Marketing & Promotion Tools
+- Campaign builder with pre-save links and social templates
+- Playlist pitching status (editorial and user curated lists)
+- Fan engagement utilities such as mailing list signups and QR code assets
+
+### Analytics Deep-Dive
+- Demographic breakdowns (age, gender and location heatmap)
+- Channel performance for video platforms and social reels
+- Comparative benchmarks against prior releases or peer artists
+
+### Rights & Royalties
+- Statement library with PDF/CSV export
+- Automated split sheet management
+- Cost dashboard to track marketing and recording spend
+
+### Collaborations & Network
+- Role assignments for team members and collaborators
+- Simple messaging hub for label and partner communication
+- Referral tracking for affiliates
+
+### Integrations & APIs
+- Connectors for major DSP dashboards
+- Optional accounting and CRM integrations
+
+## 2. Hype & Adoption Strategies
+
+- Case studies and testimonials showcasing early success stories
+- Invite-only beta access with Founders Club perks
+- Webinars, e-books and other thought-leadership content
+- Co-branding opportunities with DSPs and label programs
+- Sponsorships at industry events
+- Referral and ambassador incentives
+- Freemium tier and timed trials for premium tools
+- Press releases and influencer partnerships
+- Smooth onboarding with data import wizards
+- Clear display of certifications and a transparent fee model
+
+## Backend Route Examples
+
+| Endpoint | Purpose |
+| --- | --- |
+| `/api/dashboard/earnings` | Returns summary of artist earnings |
+| `/api/dashboard/streams` | Streaming and sales metrics |
+| `/api/dashboard/catalog` | CRUD operations for catalog metadata |
+| `/api/dashboard/campaigns` | Manage marketing campaigns |
+| `/api/dashboard/analytics` | Detailed analytics data |
+| `/api/dashboard/statements` | Downloadable royalty statements |
+| `/api/dashboard/team` | Manage team roles and permissions |
+
+These endpoints are placeholders to demonstrate how the dashboard might interact with a backend service. They can be implemented using serverless functions or a traditional API depending on infrastructure choices.


### PR DESCRIPTION
## Summary
- document Artist Dashboard backend strategy and feature ideas
- link the new plan document from the main README

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849f8019bc08328b098532f136abaed