### PR TITLE
Fix asset imports for Decoded Music logo

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -164,7 +164,7 @@ echo "🚀 Next steps:"
 echo "1. Run 'amplify add function' and select the contactFormHandler directory."
 echo "2. Run 'amplify add api' to create a REST endpoint /api/contact and connect it to your Lambda."
 echo "3. Run 'amplify push' to deploy."
-echo "4. Test /about and /contact from both header and footer."import decodedMusicLogo from "../assets/decoded-music-decoded-music-logo.png";
+echo "4. Test /about and /contact from both header and footer."import decodedMusicLogo from "../assets/decoded-music-logo.png";
 import React from 'react';
 import styles from '../styles/Footer.module.css';
 import content from '../content/landingPage.json'; // Import content
@@ -190,8 +190,7 @@ function Footer() {
       <div className={styles.container}>
         <div className={styles.brandInfo}>
           <div className={styles.logo}>
-            {/* Replace with your actual logo image or SVG */}
-            {content.footer.logoText}
+            <img src={decodedMusicLogo} alt="Decoded Music Logo" className="h-10 w-auto" />
           </div>
           <p className={styles.copyright}>{copyrightText}</p>
            {/* Added privacy note below copyright or near privacy link */}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -7,7 +7,7 @@ import { Link } from "react-router-dom";
   <Link to="/about">About</Link>
   <Link to="/contact">Contact</Link>
 </nav>
-import decodedMusicLogo from "../assets/decoded-music-decoded-music-logo.png";
+import decodedMusicLogo from "../assets/decoded-music-logo.png";
 import React, { useState } from 'react';
 import styles from '../styles/Header.module.css';
 import Button from './Button';
@@ -28,8 +28,9 @@ function Header() {
     <header className={styles.header}>
       <div className={styles.container}>
         <div className={styles.logo}>
-          {/* Replace with your actual logo image or SVG */}
-          <a href="/" onClick={handleNavLinkClick}>{content.header.logoText}</a>
+          <a href="/" onClick={handleNavLinkClick}>
+            <img src={decodedMusicLogo} alt="Decoded Music Logo" className="h-10 w-auto" />
+          </a>
         </div>
         <nav className={`${styles.nav} ${isMobileMenuOpen ? styles.mobileNavOpen : ''}`}>
           <ul>

--- a/src/sections/Section1Hero.js
+++ b/src/sections/Section1Hero.js
@@ -3,7 +3,7 @@ import styles from '../styles/Section1Hero.module.css';
 import Button from '../components/Button';
 import content from '../content/landingPage.json'; // Import content
 // Import your logo image here
-import decodedMusicLogo from '../assets/decoded-music-decoded-music-logo.png'; // Make sure you have the logo image
+import decodedMusicLogo from '../assets/decoded-music-logo.png';
 
 function Section1Hero() {
   return (
@@ -17,7 +17,7 @@ function Section1Hero() {
         <div className={styles.overlay}></div> {/* Dark overlay */}
       </div>
       <div className={styles.framedContent}> {/* New container for the "framed" look */}
-        <img src={decodedMusicLogo} alt={content.hero.logoAltText} className={styles.logo} />
+        <img src={decodedMusicLogo} alt="Decoded Music Logo" className="h-10 w-auto" />
         <h1 className={styles.headline}>{content.hero.headline}</h1>
         <p className={styles.tagline}>{content.hero.tagline}</p> {/* Use tagline from JSON */}
         <p className={styles.hypeText}>

--- a/src/sections/Section8AWS.js
+++ b/src/sections/Section8AWS.js
@@ -1,4 +1,4 @@
-import decodedMusicLogo from "../assets/decoded-music-decoded-music-logo.png";
+import decodedMusicLogo from "../assets/decoded-music-logo.png";
 import React from 'react';
 import styles from '../styles/Section8AWS.module.css';
 import content from '../content/landingPage.json'; // Import content
@@ -10,6 +10,7 @@ function Section8AWS() {
     <section className={styles.section}>
       <div className={styles.container}>
          <div className={styles.logoBlock}>
+            <img src={decodedMusicLogo} alt="Decoded Music Logo" className="h-10 w-auto" />
             <img src={awsLogo} alt="Powered by AWS" className={styles.awsLogo} />
          </div>
          <div className={styles.textBlock}>


### PR DESCRIPTION
## Summary
- update path to `decoded-music-logo.png`
- replace logo text with `<img>` tag in header, footer, and hero sections
- display logo alongside AWS logo

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b3e6c4c208328a35e267f86f97d18