### PR TITLE
Add Amplify build config with backend and frontend phases

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,21 +1,32 @@
-# This Amplify build script ensures Node.js 18.x (LTS) is used for your app
-
 version: 1
+
+# 1) Build and deploy your Amplify backend
+backend:
+  phases:
+    preBuild:
+      commands:
+        # install the Amplify CLI so amplifyPush is available
+        - npm install -g @aws-amplify/cli
+    build:
+      commands:
+        # this helper will push your current branch's backend config
+        - amplifyPush --simple
+
+# 2) Then build your React front-end
 frontend:
   phases:
     preBuild:
       commands:
-        - nvm install 18
-        - nvm use 18
-        - node -v   # Optional: print Node version for debugging
-        - npm install
+        - cd decodedmusic-frontend
+        - npm ci
     build:
       commands:
         - npm run build
   artifacts:
-    baseDirectory: build
+    # where your React build ends up
+    baseDirectory: decodedmusic-frontend/build
     files:
       - '**/*'
   cache:
     paths:
-      - node_modules/**/*
+      - decodedmusic-frontend/node_modules/**/*


### PR DESCRIPTION
## Summary
- provide new `amplify.yml` to deploy Amplify backend then build React app in `decodedmusic-frontend`

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_684b4ba927fc8328ba3d18fb5e9c6a90