### PR TITLE
Fix Amplify build

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -20,7 +20,7 @@ frontend:
     preBuild:
       commands:
         - cd decodedmusic-frontend
-        - npm ci
+        - npm install
     build:
       commands:
         - npm run build


### PR DESCRIPTION
## Summary
- swap out `npm ci` for `npm install` in Amplify build so the deployment can succeed

## Testing
- `npm test --silent -- --watchAll=false` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684b6604baf483289b59aa73bf9610a5