### PR TITLE
Add automated lockfile sync workflow

### DIFF
--- a/.github/workflows/sync-lockfile.yml
+++ b/.github/workflows/sync-lockfile.yml
@@ -1,0 +1,19 @@
+name: Sync Package Lock
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Run lockfile sync script
+        run: |
+          bash automate-sync-lockfile.sh

--- a/automate-sync-lockfile.sh
+++ b/automate-sync-lockfile.sh
@@ -4,11 +4,16 @@
 
 set -e
 
+# Configure git user for non-interactive environments
+git config user.name "${GIT_USER_NAME:-github-actions}"
+git config user.email "${GIT_USER_EMAIL:-github-actions@github.com}"
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT" || exit 1
 
 echo "➡️ Pulling latest changes"
-git pull origin main
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+git pull origin "$BRANCH"
 
 FRONTEND_DIR="decodedmusic-frontend"
 cd "$FRONTEND_DIR" || exit 1
@@ -28,6 +33,6 @@ git add "$FRONTEND_DIR/package.json" "$FRONTEND_DIR/package-lock.json"
 git commit -m "chore: sync package-lock.json with package.json"
 
 echo "➡️ Pushing changes"
-git push
+git push origin "$BRANCH"
 
 echo "✅ Lockfile synchronized"


### PR DESCRIPTION
## Summary
- set GitHub user in `automate-sync-lockfile.sh`
- use current branch when pulling/pushing in the script
- add a workflow to run the lockfile sync script weekly or manually

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b68cec44083289e09f50daebb5859