### PR TITLE
Fix Amplify build to wipe npm cache

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -20,7 +20,9 @@ frontend:
     preBuild:
       commands:
         - cd decodedmusic-frontend
-        - npm install
+        - npm cache clean --force
+        - rm -rf node_modules
+        - npm ci
     build:
       commands:
         - npm run build
@@ -31,4 +33,5 @@ frontend:
       - '**/*'
   cache:
     paths:
-      - decodedmusic-frontend/node_modules/**/*
+      # - decodedmusic-frontend/node_modules/**/*
+      - ~/.npm


### PR DESCRIPTION
## Summary
- wipe npm cache in Amplify prebuild step
- drop cached node_modules to avoid corruption
- only cache the npm directory

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `(cd decodedmusic-frontend && npm test --silent)` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b6cd776a08328b742201723828cbf