### PR TITLE
Add setup instructions for Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,15 @@ These values are read by the front-end to initiate the login process.
 *   Add actual icons and refine styling based on detailed design assets.
 *   See [docs/artist-dashboard-plan.md](docs/artist-dashboard-plan.md) for a
     proposed Artist Dashboard backend and adoption strategy.
+
+## Running in Codex
+
+If you encounter a message like "Codex couldn't run certain commands due to environment limitations," make sure the container installs dependencies before running tests or other commands. A simple `setup.sh` script can be used:
+
+```bash
+#!/bin/bash
+set -e
+npm install
+```
+
+Run this script manually or in your CI pipeline so the environment has the required packages when Codex executes your commands.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Install dependencies required for building and testing
+if command -v npm >/dev/null 2>&1; then
+  npm install
+else
+  echo "npm not found. Please install Node.js before running this script." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- document how to run the project inside Codex
- add `setup.sh` script to install Node dependencies

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b7deba2708328bcbc452cdec98a6a