### PR TITLE
Fix missing UI imports to unblock build

### DIFF
--- a/src/components/catalog/TrackCard.jsx
+++ b/src/components/catalog/TrackCard.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Card, CardContent, CardFooter, Button } from "@/components/ui";
+import { Card, CardContent, CardFooter, Button } from "../ui";
 
 export default function TrackCard({ track }) {
   return (

--- a/src/components/ui/Card.jsx
+++ b/src/components/ui/Card.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export function Card({ children, className = '' }) {
+  return <div className={`bg-[#222] rounded-lg shadow-md ${className}`}>{children}</div>;
+}
+
+export function CardContent({ children, className = '' }) {
+  return <div className={`p-4 ${className}`}>{children}</div>;
+}
+
+export function CardFooter({ children, className = '' }) {
+  return <div className={`p-4 border-t border-gray-700 ${className}`}>{children}</div>;
+}

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -1,0 +1,2 @@
+export { default as Button } from '../Button';
+export * from './Card';


### PR DESCRIPTION
## Summary
- provide simple Card components
- export them through a small ui library
- update TrackCard to import from new ui path

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b965805ac8328a0578366e94b057e