### PR TITLE
Fix npm cache persistence

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -32,6 +32,4 @@ frontend:
     files:
       - '**/*'
   cache:
-    paths:
-      # - decodedmusic-frontend/node_modules/**/*
-      - ~/.npm
+    paths: []


### PR DESCRIPTION
## Summary
- disable the npm cache path in `amplify.yml` so Amplify always installs packages fresh

## Testing
- `npm install` *(fails: 403 Forbidden, registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_684c752dd3548328939386c7a7dbd733